### PR TITLE
Expose loadFromArrayBuffer for loading wasm from buffer instead of url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@descript/superpowered",
   "description": "Superpowered interactive audio features in JavaScript + WebAssembly.",
-  "version": "2.2.0-rc12",
+  "version": "2.2.0-rc13",
   "browser": "superpowered.js",
   "scripts": {
     "test": "echo \"No test specified.\" && exit 1",

--- a/superpowered/SuperpoweredGlueModule.d.ts
+++ b/superpowered/SuperpoweredGlueModule.d.ts
@@ -1,6 +1,12 @@
-import {Superpowered, SuperpoweredFloat32Buffer} from "./Superpowered";
+import { Superpowered } from "./Superpowered";
 
 export declare class SuperpoweredGlue {
-  constructor();
-  static fetch: (url: string) => Promise<Superpowered>;
+    constructor();
+    static fetch: (url: string) => Promise<Superpowered>;
+    loadFromArrayBuffer(
+        wasmCode: BufferSource,
+        afterWASMLoaded?: {
+            afterWASMLoaded: () => void;
+        },
+    ): Promise<void>;
 }


### PR DESCRIPTION
We're probably going to want this alternate approach to loading the wasm on the backend (where we're not packaging with webpack).